### PR TITLE
Codecov partial coverage example

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,10 @@
+Only works on Linux currently (something to do with C++ toolchains)
+
+Full coverage: ./full_coverage.sh
+
+Lib2 coverage: ./partial_coverage.sh
+
+Remove non affected files: ./diff_cover.py
+
+Upload to codecov: ./upload_cov.sh
+    (requires codecov binary available)

--- a/diff_cover.py
+++ b/diff_cover.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+LCOV_FILE="bazel-out/_coverage/_coverage_report.dat"
+
+
+files = subprocess.check_output([
+    "git",
+    "diff",
+    "--name-only",
+    "HEAD..origin/master",
+]).decode().strip().split("\n")
+
+subprocess.check_call([
+    "lcov",
+    "-e",
+    LCOV_FILE,
+    "-o",
+    "diff.lcov"
+] + files)
+
+
+
+
+    

--- a/lib2/lib.cpp
+++ b/lib2/lib.cpp
@@ -10,6 +10,9 @@ void newcode() {
     }
 }
 
+void morecode() {
+    std::cout << "yes";
+}
 
 void lib2::somethingElse() {
   common::h();

--- a/lib2/lib.h
+++ b/lib2/lib.h
@@ -1,3 +1,5 @@
 namespace lib2 {
   void somethingElse();
 }
+
+

--- a/upload_cov.sh
+++ b/upload_cov.sh
@@ -1,4 +1,4 @@
 set -x
 
-file="bazel-out/_coverage/_coverage_report.dat"
+file="diff.lcov"
 ./codecov -t $(cat codecov_token) -C $(git rev-parse HEAD) -f $file

--- a/upload_cov.sh
+++ b/upload_cov.sh
@@ -1,4 +1,4 @@
 set -x
 
 file="diff.lcov"
-./codecov -t $(cat codecov_token) -C $(git rev-parse HEAD) -f $file
+./codecov -t $(cat codecov_token) -C $(git rev-parse HEAD) -f $file -N 4035c26bd89c88097732178553bd7bc91a084d88


### PR DESCRIPTION
This PR touches lib2/ so we only run tests from lib2/.

This is what we have on Codecov: https://app.codecov.io/gh/gabrielrussoc/codecov-example/commit/58e250609daab9917d90851bc8952a593f909ba3

This is the raw coverage report: https://storage.googleapis.com/codecov/v4/raw/2022-07-20/3F3F7ECFC5C9992E4C6D04E7608DC3C8/58e250609daab9917d90851bc8952a593f909ba3/13bdf69a-6b73-45d0-9de6-389c00e116de.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=GOOG1EJOGFN2JQ4OCTGA2MU5AEIT7OT5Z7HTFOAN2SPG4NWSN2UJYOY5U6LZQ%2F20220801%2FUS%2Fs3%2Faws4_request&X-Amz-Date=20220801T092239Z&X-Amz-Expires=10&X-Amz-SignedHeaders=host&X-Amz-Signature=e37690184d5cedd5b1ed8271e3adf010a00b2a7355829887d30ffdaaef6d46e3

Note that the codecov comment includes every single file on the repo with no data (even though they are completely irrelevant for this PR) and it says the coverage decreases by 70% for the entire repo, which is also not true since codecov doesn't have enough data from all the tests to infer that.